### PR TITLE
Add compact view toggle to Recent Account List component

### DIFF
--- a/force-app/main/default/lwc/recentAccountList/recentAccountList.html
+++ b/force-app/main/default/lwc/recentAccountList/recentAccountList.html
@@ -1,5 +1,14 @@
 <template>
   <lightning-card title="Recent Accounts" icon-name="standard:account">
+    <div slot="actions">
+      <lightning-button-icon
+        icon-name={viewToggleIcon}
+        variant="border-filled"
+        alternative-text={viewToggleAltText}
+        title={viewToggleTitle}
+        onclick={handleViewToggle}
+      ></lightning-button-icon>
+    </div>
     <div class="slds-p-horizontal_medium">
       <!-- Error State -->
       <div
@@ -15,74 +24,100 @@
         </div>
       </div>
 
-      <!-- Recent Accounts Tiles -->
+      <!-- Recent Accounts Display -->
       <div lwc:elseif={hasAccounts}>
-        <ul class="slds-has-dividers_around-space">
-          <li
-            for:each={accounts}
-            for:item="account"
-            key={account.Id}
-            class="slds-item"
-          >
-            <article class="slds-tile">
-              <h3 class="slds-tile__title slds-truncate" title={account.Name}>
+        <!-- Detailed View -->
+        <div lwc:if={isDetailedView}>
+          <ul class="slds-has-dividers_around-space">
+            <li
+              for:each={accounts}
+              for:item="account"
+              key={account.Id}
+              class="slds-item"
+            >
+              <article class="slds-tile">
+                <h3 class="slds-tile__title slds-truncate" title={account.Name}>
+                  <a
+                    href="#"
+                    data-account-id={account.Id}
+                    onclick={handleAccountClick}
+                  >
+                    {account.Name}
+                  </a>
+                </h3>
+                <div class="slds-tile__detail">
+                  <dl class="slds-list_horizontal slds-wrap">
+                    <dt
+                      lwc:if={account.Phone}
+                      class="slds-item_label slds-text-color_weak slds-truncate"
+                    >
+                      Phone:
+                    </dt>
+                    <dd
+                      lwc:if={account.Phone}
+                      class="slds-item_detail slds-truncate"
+                    >
+                      {account.Phone}
+                    </dd>
+                    <dt
+                      lwc:if={account.Website}
+                      class="slds-item_label slds-text-color_weak slds-truncate"
+                    >
+                      Website:
+                    </dt>
+                    <dd
+                      lwc:if={account.Website}
+                      class="slds-item_detail slds-truncate"
+                    >
+                      <a
+                        href={account.Website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {account.Website}
+                      </a>
+                    </dd>
+                    <dt
+                      lwc:if={account.LastModifiedDate}
+                      class="slds-item_label slds-text-color_weak slds-truncate"
+                    >
+                      Last updated:
+                    </dt>
+                    <dd
+                      lwc:if={account.LastModifiedDate}
+                      class="slds-item_detail slds-truncate"
+                    >
+                      {account.formattedLastModified}
+                    </dd>
+                  </dl>
+                </div>
+              </article>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Compact View -->
+        <div lwc:else>
+          <ul class="slds-has-dividers_bottom-space">
+            <li
+              for:each={accounts}
+              for:item="account"
+              key={account.Id}
+              class="slds-item slds-p-vertical_small"
+            >
+              <div class="slds-truncate">
                 <a
                   href="#"
                   data-account-id={account.Id}
                   onclick={handleAccountClick}
+                  class="slds-text-heading_small"
                 >
                   {account.Name}
                 </a>
-              </h3>
-              <div class="slds-tile__detail">
-                <dl class="slds-list_horizontal slds-wrap">
-                  <dt
-                    lwc:if={account.Phone}
-                    class="slds-item_label slds-text-color_weak slds-truncate"
-                  >
-                    Phone:
-                  </dt>
-                  <dd
-                    lwc:if={account.Phone}
-                    class="slds-item_detail slds-truncate"
-                  >
-                    {account.Phone}
-                  </dd>
-                  <dt
-                    lwc:if={account.Website}
-                    class="slds-item_label slds-text-color_weak slds-truncate"
-                  >
-                    Website:
-                  </dt>
-                  <dd
-                    lwc:if={account.Website}
-                    class="slds-item_detail slds-truncate"
-                  >
-                    <a
-                      href={account.Website}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {account.Website}
-                    </a>
-                  </dd>
-                  <dt
-                    lwc:if={account.LastModifiedDate}
-                    class="slds-item_label slds-text-color_weak slds-truncate"
-                  >
-                    Last updated:
-                  </dt>
-                  <dd
-                    lwc:if={account.LastModifiedDate}
-                    class="slds-item_detail slds-truncate"
-                  >
-                    {account.formattedLastModified}
-                  </dd>
-                </dl>
               </div>
-            </article>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <!-- No Recent Accounts Message -->

--- a/force-app/main/default/lwc/recentAccountList/recentAccountList.js
+++ b/force-app/main/default/lwc/recentAccountList/recentAccountList.js
@@ -1,4 +1,4 @@
-import { LightningElement, wire } from "lwc";
+import { LightningElement, wire, track } from "lwc";
 import { NavigationMixin } from "lightning/navigation";
 import getRecentAccounts from "@salesforce/apex/AccountController.getRecentAccounts";
 
@@ -7,6 +7,7 @@ export default class RecentAccountList extends NavigationMixin(
 ) {
   accounts;
   error;
+  @track isDetailedView = true;
 
   @wire(getRecentAccounts)
   wiredRecentAccounts({ error, data }) {
@@ -40,6 +41,42 @@ export default class RecentAccountList extends NavigationMixin(
   }
 
   /**
+   * @description Determines if the component is in compact view mode
+   * @returns {boolean} True if in compact view
+   */
+  get isCompactView() {
+    return !this.isDetailedView;
+  }
+
+  /**
+   * @description Gets the appropriate icon for the view toggle button
+   * @returns {string} Icon name for current view state
+   */
+  get viewToggleIcon() {
+    return this.isDetailedView ? "utility:list" : "utility:tile_card_list";
+  }
+
+  /**
+   * @description Gets the alternative text for the view toggle button
+   * @returns {string} Alt text for accessibility
+   */
+  get viewToggleAltText() {
+    return this.isDetailedView
+      ? "Switch to compact view"
+      : "Switch to detailed view";
+  }
+
+  /**
+   * @description Gets the title text for the view toggle button
+   * @returns {string} Title text for button hover
+   */
+  get viewToggleTitle() {
+    return this.isDetailedView
+      ? "Switch to compact view"
+      : "Switch to detailed view";
+  }
+
+  /**
    * @description Formats a date for display
    * @param {string} dateString The date string to format
    * @returns {string} Formatted date string
@@ -67,5 +104,14 @@ export default class RecentAccountList extends NavigationMixin(
         }
       });
     }
+  }
+
+  /**
+   * @description Handles the view toggle button click to switch between detailed and compact views
+   * @param {Event} event The click event
+   */
+  handleViewToggle(event) {
+    event.preventDefault();
+    this.isDetailedView = !this.isDetailedView;
   }
 }


### PR DESCRIPTION
## Summary
This PR implements the compact view toggle feature requested in issue #3.

## Changes Made
- ✅ Added `lightning-button-icon` toggle control in the card's actions area
- ✅ Implemented detailed view with full account information (Phone, Website, Last Modified Date)
- ✅ Implemented compact view showing only account names in a streamlined list
- ✅ Added toggle state management using `@track` decorator for reactivity
- ✅ Included proper accessibility attributes with dynamic alt text and titles
- ✅ Used appropriate SLDS icons that change based on current view state
- ✅ Maintained navigation functionality in both view modes
- ✅ Preserved existing error handling and empty state displays

## Technical Details
- **HTML Template**: Updated with conditional rendering using proper `lwc:if`/`lwc:else` structure
- **JavaScript**: Added reactive properties and computed getters for view state management
- **Accessibility**: Implemented proper ARIA attributes and descriptive button text
- **Styling**: Used SLDS classes for consistent design across both views

## Testing
- ✅ Successfully deployed to scratch org
- ✅ Passed all pre-commit hooks (linting, formatting, Jest tests)
- ✅ Toggle functionality works correctly between views
- ✅ Account navigation preserved in both modes

## Screenshots
**Detailed View (Default)**:
- Shows account tiles with full information (Phone, Website, Last Modified)
- Toggle button displays list icon

**Compact View**:
- Shows streamlined list with only account names
- Toggle button displays tile card list icon

Fixes #3